### PR TITLE
Use default cURL timeouts by default to prevent accidental functional test failures on Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+composer.lock
 vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+  - nightly
 
 before_script:
   - phpenv rehash

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
+        "phpunit/phpunit": "^4.0||^5.0",
         "corneltek/phpunit-testmore": "dev-master"
     },
     "extra": { "branch-alias": { "dev-master": "1.0.x-dev" } },

--- a/src/CurlKit/CurlDownloader.php
+++ b/src/CurlKit/CurlDownloader.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace CurlKit;
+
 use CurlKit\Progress\CurlProgressInterface;
-use CurlKit\CurlException;
 
 /**
  * $downloader = new CurlKit/CurlDownloader;
@@ -21,7 +22,6 @@ use CurlKit\CurlException;
  *
  * ));
  */
-use Exception;
 
 class CurlDownloader 
 {
@@ -41,9 +41,9 @@ class CurlDownloader
 
     public $bufferSize = 512;
 
-    public $connectionTimeout = 10;
+    public $connectionTimeout;
 
-    public $timeout = 36000;
+    public $timeout;
 
     public $progress;
 
@@ -60,7 +60,16 @@ class CurlDownloader
 
     public function createCurlResource( $extra = array() ) 
     {
-        $ch = curl_init(); 
+        $ch = curl_init();
+
+        if ($this->connectionTimeout !== null) {
+            curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->connectionTimeout);
+        }
+
+        if ($this->timeout !== null) {
+            curl_setopt($ch, CURLOPT_TIMEOUT, $this->timeout);
+        }
+
         curl_setopt_array($ch, (
             $this->options 
                 + array( 
@@ -69,14 +78,8 @@ class CurlDownloader
 
                     CURLOPT_BUFFERSIZE => $this->bufferSize,
 
-                    // connection timeout
-                    CURLOPT_CONNECTTIMEOUT => $this->connectionTimeout,
-
                     // GitHub https will block this if user agent is not given.
                     CURLOPT_USERAGENT => $this->userAgent,
-
-                    // max function call timeout
-                    CURLOPT_TIMEOUT => $this->timeout,
                 ) 
                 + $extra
         )); 


### PR DESCRIPTION
Some tests on Travis CI fail because of connection timeout when connection to pear.php.net:

1. https://travis-ci.org/phpbrew/phpbrew/jobs/285966800
2. https://travis-ci.org/phpbrew/phpbrew/jobs/287167227
3. https://travis-ci.org/phpbrew/phpbrew/jobs/290106834

It may help if the wrapper uses default cURL timouts by default:

1. https://curl.haxx.se/libcurl/c/CURLOPT_CONNECTTIMEOUT.html
2. https://curl.haxx.se/libcurl/c/CURLOPT_TIMEOUT.html