### PR TITLE
Update CurlDownloader.php

### DIFF
--- a/src/CurlKit/CurlDownloader.php
+++ b/src/CurlKit/CurlDownloader.php
@@ -165,7 +165,7 @@ class CurlDownloader
 
         // When using HTTP TUNNEL, there is an extra response line before the 
         // original response line, we need to separate them if it matches "Connection established"
-        if (preg_match('#HTTP/1.[0-1] 200 Connection established#i', $data)) {
+        if (preg_match('#HTTP/1.[0-1] 200#i', $data)) {
             list($proxyResponseLine, $headers, $body) = explode("\r\n\r\n", $data, 3);
         } else {
             list($headers, $body) = explode("\r\n\r\n", $data, 2);


### PR DESCRIPTION
使用http proxy 返回的原始数据为

HTTP/1.1 200 OK
Date: Monday, 26-Feb-18 12:01:58 CST
Keep-Alive: timeout=38
Content-Length: 0

HTTP/1.1 200 OK
Date: Mon, 26 Feb 2018 04:01:59 GMT
Server: Apache/2.4.25 (Debian)
Last-Modified: Sun, 31 Dec 2017 04:18:46 GMT
ETag: "6c5-5619b297052f6"
Accept-Ranges: bytes
Content-Length: 1733
Vary: Accept-Encoding
Strict-Transport-Security: max-age=31536000
Content-Type: application/xml

<?xml version="1.0" encoding="UTF-8" ?>
.......

在http proxy模式下，会导致phpbrew ext known $ext 和 phpbrew ext install $ext $version报错