### PR TITLE
Fixed parsing headers when using an HTTP tunnel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
@@ -10,12 +8,11 @@ php:
 
 before_script:
   - phpenv rehash
-  - composer self-update
   - composer require satooshi/php-coveralls "^1" --no-update --dev
   - composer install
 
 script:
-  - phpunit
+  - vendor/bin/phpunit
 
 after_script:
   - php vendor/bin/coveralls -v

--- a/src/CurlKit/CurlDownloader.php
+++ b/src/CurlKit/CurlDownloader.php
@@ -163,10 +163,13 @@ class CurlDownloader
         $headers = '';
         $body = '';
 
-        // When using HTTP TUNNEL, there is an extra response line before the 
-        // original response line, we need to separate them if it matches "Connection established"
-        if (preg_match('#HTTP/1.[0-1] 200#i', $data)) {
-            list($proxyResponseLine, $headers, $body) = explode("\r\n\r\n", $data, 3);
+        // When using an HTTP TUNNEL, any 2xx (Successful) response indicates that the sender (and all inbound proxies)
+        // will switch to tunnel mode immediately after the blank line that concludes the successful response's header
+        // section; data received after that blank line is from the server identified by the request-target.
+        //
+        // @see https://greenbytes.de/tech/webdav/draft-ietf-httpbis-p2-semantics-26.html#CONNECT
+        if ($this->proxy !== null) {
+            list(, $headers, $body) = explode("\r\n\r\n", $data, 3);
         } else {
             list($headers, $body) = explode("\r\n\r\n", $data, 2);
         }

--- a/tests/CurlKit/CurlAgentTest.php
+++ b/tests/CurlKit/CurlAgentTest.php
@@ -37,9 +37,14 @@ class CurlAgentTest extends PHPUnit_Framework_TestCase
     }
 
     public function testingProxy() {
-        skip('skip proxy testing');
+        $proxy = getenv('http_proxy');
+
+        if ($proxy === false) {
+            skip('Set an HTTP proxy using the http_proxy environment variable');
+        }
+
         $agent = new CurlKit\CurlAgent;
-        $agent->setProxy('106.187.96.49:3128');
+        $agent->setProxy($proxy);
         $response = $agent->get('https://stackoverflow.com/questions/11297320/using-a-try-catch-with-curl-in-php');
         ok($response);
         ok($response->body);

--- a/tests/CurlKit/DownloaderTest.php
+++ b/tests/CurlKit/DownloaderTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use CurlKit\CurlDownloader;
+
+class DownloaderTest extends PHPUnit_Framework_TestCase
+{
+    public function testDownloadDefault()
+    {
+        $this->assertDownload(new CurlDownloader());
+    }
+
+    public function testDownloadViaProxy()
+    {
+        $proxy = getenv('http_proxy');
+
+        if ($proxy === false) {
+            skip('Set an HTTP proxy using the http_proxy environment variable');
+        }
+
+        $downloader = new CurlDownloader();
+        $downloader->setProxy($proxy);
+
+        $this->assertDownload($downloader);
+    }
+
+    private function assertDownload(CurlDownloader $downloader)
+    {
+        $response = $downloader->request('https://httpbin.org/get');
+
+        $data = json_decode($response, true);
+        $this->assertSame(JSON_ERROR_NONE, json_last_error());
+        $this->assertSame('https://httpbin.org/get', $data['url']);
+    }
+}


### PR DESCRIPTION
According to the [article](https://greenbytes.de/tech/webdav/draft-ietf-httpbis-p2-semantics-26.html#CONNECT),

> Any 2xx (Successful) response indicates that the sender (and all inbound proxies) will switch to tunnel mode immediately after the blank line that concludes the successful response's header section; data received after that blank line is from the server identified by the request-target.

So the change in #4 was correct about the fact that the "Connection established" shouldn't always be expected in the server response.

Although, the correct approach is to base the logic on whether the connection itself is proxied, rather than on the response content. Otherwise, any successful response will match the condition for a proxied one.

At the time of the change, the affected code was not covered by a test.

Fixes #7.