### PR TITLE
Integrating GitHub CI and add PHP-7.2 at least

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  run:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl, zip, xml
+          coverage: none
+
+      - name: Install dependencies
+        uses: ramsey/composer-install@v2
+
+      - name: Update PHPUnit
+        run: composer update phpunit/phpunit --with-dependencies
+
+      - name: Run test suite
+        run: vendor/bin/phpunit --exclude-group noPearSymfony

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,10 @@
     "description": "Curl Kit",
     "license": "MIT",
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=7.2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.0||^5.0",
+        "phpunit/phpunit": "^8.5||^9.5",
         "corneltek/phpunit-testmore": "dev-master"
     },
     "extra": { "branch-alias": { "dev-master": "1.0.x-dev" } },

--- a/tests/CurlKit/CurlAgentTest.php
+++ b/tests/CurlKit/CurlAgentTest.php
@@ -1,14 +1,14 @@
 <?php
 
-class CurlAgentTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class CurlAgentTest extends TestCase
 {
 
-    /**
-     * @expectedException CurlKit\CurlException
-     */
     public function testError() {
         $agent = new CurlKit\CurlAgent;
         ok($agent);
+        $this->expectException('CurlKit\\CurlException');
         $response = $agent->get('http://does.not.exist');
     }
 
@@ -17,7 +17,7 @@ class CurlAgentTest extends PHPUnit_Framework_TestCase
         $agent = new CurlKit\CurlAgent;
         ok($agent);
 
-        $response = $agent->get('https://stackoverflow.com/questions/11297320/using-a-try-catch-with-curl-in-php');
+        $response = $agent->get('https://github.com');
         ok($response);
         ok($response->body);
         ok($response->headers);
@@ -29,7 +29,7 @@ class CurlAgentTest extends PHPUnit_Framework_TestCase
         $agent = new CurlKit\CurlAgent;
         ok($agent);
 
-        $response = $agent->head('http://httpbin.org/');
+        $response = $agent->head('https://github.com');
         ok($response);
         is('', $response->body);
         ok($response->headers);
@@ -45,7 +45,7 @@ class CurlAgentTest extends PHPUnit_Framework_TestCase
 
         $agent = new CurlKit\CurlAgent;
         $agent->setProxy($proxy);
-        $response = $agent->get('https://stackoverflow.com/questions/11297320/using-a-try-catch-with-curl-in-php');
+        $response = $agent->get('https://github.com');
         ok($response);
         ok($response->body);
         ok($response->headers);

--- a/tests/CurlKit/DownloaderTest.php
+++ b/tests/CurlKit/DownloaderTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use CurlKit\CurlDownloader;
+use PHPUnit\Framework\TestCase;
 
-class DownloaderTest extends PHPUnit_Framework_TestCase
+class DownloaderTest extends TestCase
 {
     public function testDownloadDefault()
     {
@@ -25,10 +26,10 @@ class DownloaderTest extends PHPUnit_Framework_TestCase
 
     private function assertDownload(CurlDownloader $downloader)
     {
-        $response = $downloader->request('https://httpbin.org/get');
+        $response = $downloader->request('https://api.github.com');
 
         $data = json_decode($response, true);
         $this->assertSame(JSON_ERROR_NONE, json_last_error());
-        $this->assertSame('https://httpbin.org/get', $data['url']);
+        $this->assertSame('https://api.github.com/user', $data['current_user_url']);
     }
 }


### PR DESCRIPTION
# Changed log

- Adding `PHP 7.2` requirement at least to be compatible with PHPBrew PHP version requirement.
- Integrating the GitHub CI and adding from PHP 7.2 to 8.2  version tests.
- Upgrading PHPUnit to support `PHP 7.2+` versions.
- Some website URLs are dead or problematic during CurlAgent and Downloader tests running, and it can use the `https://github.com` and `https://api.github.com` to complete these real tests conveniently.